### PR TITLE
remove null-aware operation which is not needed

### DIFF
--- a/lib/widget_to_image.dart
+++ b/lib/widget_to_image.dart
@@ -29,7 +29,7 @@ class WidgetToImage {
 				size: size,
 				devicePixelRatio: devicePixelRatio,
 			),
-			window: WidgetsBinding.instance!.platformDispatcher.views.first,
+			window: WidgetsBinding.instance.platformDispatcher.views.first,
 		);
 
 		PipelineOwner pipelineOwner = PipelineOwner();


### PR DESCRIPTION
You can see some worming shown when upgrade to flutter 3 and it's simply solve by remove null-aware operation.
Thanks for this amazing tool, you made a lot of work easier for me