### PR TITLE
Make widgetToImage() require a size parameter, fix example app to supply size, fixes #18

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,11 +79,14 @@ class MyHomePageState extends State<MyHomePage> {
 	}
 
 	_callWidgetToImage() async {
-		ByteData byteData = await WidgetToImage.widgetToImage(Container(
-			width: 100,
-			height: 100,
-			color: Colors.blue,
-		));
+		ByteData byteData = await WidgetToImage.widgetToImage(
+      Container(
+        width: 100,
+        height: 100,
+        color: Colors.blue,
+      ),
+      size: Size(100,100),
+    );
 		setState(() => _byteData = byteData);
 	}
 }

--- a/lib/widget_to_image.dart
+++ b/lib/widget_to_image.dart
@@ -17,7 +17,7 @@ class WidgetToImage {
 
 	static Future<ByteData> widgetToImage(Widget widget, {
 		Alignment alignment = Alignment.center,
-		Size size = const Size(double.maxFinite, double.maxFinite),
+		required Size size,
 		double devicePixelRatio = 1.0,
 		double pixelRatio = 1.0
 	}) async {
@@ -29,7 +29,7 @@ class WidgetToImage {
 				size: size,
 				devicePixelRatio: devicePixelRatio,
 			),
-			window: WidgetsBinding.instance!.platformDispatcher.views.first,
+			window: WidgetsBinding.instance.platformDispatcher.views.first,
 		);
 
 		PipelineOwner pipelineOwner = PipelineOwner();


### PR DESCRIPTION
This PR makes `widgetToImage()` require a size parameter.  The default of `Size(double.maxFinite, double.maxFinite)` prevents it from returning anything but a blank image and making it appear that the function does not work.  That is clearly *not* a good default.

Also fix the example to supply a size parameter for it's `widgetToImage()` demonstration so that it now actually demonstrates that this function works instead of just showing a blank result.